### PR TITLE
SOL-150196: Update golang.org/x/net/idna package to 0.54.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
-	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.12.0 // indirect


### PR DESCRIPTION
Jira: https://sol-jira.atlassian.net/browse/SOL-150196

### What was the purpose of this change?
- Fix CVE-2026-39821 privilege escalation vulnerability in golang.org/x/net/idna package by upgrading to the patched version.
### How was this accomplished?
- Pinned golang.org/x/net version to v0.54.0 in go.mod file (upgraded from v0.52.0).